### PR TITLE
buildPortRange method bug-fix (and improved)

### DIFF
--- a/src/mud_manager.c
+++ b/src/mud_manager.c
@@ -62,7 +62,13 @@ int buildPortRange(char *portBuf, int portBufSize, AceEntry *ace)
 {
 	int retval = 0; /* Return > 0 if there is an error with port assignments */
 
-	snprintf(portBuf, portBufSize, "%s:%s", ace->lowerPort, ace->upperPort);
+	// It is necessary to verify if port range is specified. If not "any" will be used.
+	if (ace->lowerPort == NULL)
+		snprintf(portBuf, portBufSize, "any");
+	else if (ace->upperPort == NULL)
+		snprintf(portBuf, portBufSize, "any");
+	else
+		snprintf(portBuf, portBufSize, "%s-%s", ace->lowerPort, ace->upperPort);
 	portBuf[portBufSize-1] = '\0';
 
 	return retval;


### PR DESCRIPTION
---

Bug-fix: to be compliant with the OpenWRT documentation, it is necessary to specify the port range with a dash instead of using the column.

More info on [OpenWRT doc](https://openwrt.org/docs/guide-user/firewall/firewall_configuration#rules)

---

If the port range is not specified the MUD manager will not work properly. For this reason, I updated buildPortRange function to replace NULL with "any".

---