### PR TITLE
DHCP Requests from "OLD" devices are now processed

### DIFF
--- a/src/dhcp_event.c
+++ b/src/dhcp_event.c
@@ -77,7 +77,7 @@ void doDhcpLegacyAction(DhcpEvent *dhcpEvent)
 
 int validateMudFileWithSig(DhcpEvent *dhcpEvent)
 {
-	int validSig = -1; /* Indicates invalid signature. 0 = valid sig, non-zero is specific signature validation error */
+	int validSig = INVALID_MUD_FILE_SIG; /* Indicates invalid signature. 0 = valid sig, non-zero is specific signature validation error */
 
 	logOmsGeneralMessage(OMS_DEBUG, OMS_SUBSYS_GENERAL, "IN ****NEW**** validateMudFileWithSig()");
 


### PR DESCRIPTION
# Updated MUD files from OLD devices are now processed

When osMUD receives a DHCP request from an already connected device, it retrieves the MUD file and verifies if it has been changed in the elapsed time.
If so, the old rules are deleted, and the new MUD policies are instantiated.

## Code refactoring

To introduce this change I slightly refactored the code. In particular:
- I introduced a function called enforceMudPolicies( ) to be used both by executeNewDhcpAction( ) and executeOldDhcpAction( )
- I improved the error management
- I added more debug statement
